### PR TITLE
added argument for directory in docopt help section

### DIFF
--- a/imap_cli/delete.py
+++ b/imap_cli/delete.py
@@ -7,7 +7,7 @@ Usage: imap-cli-delete [options] <mail_id>...
 
 Options:
     -c, --config-file=<FILE>    Configuration file
-    -d, --directory             Specify a Mailbox
+    -d, --directory MAILBOX     Specify a Mailbox
     -v, --verbose               Generate verbose messages
     -h, --help                  Show help options.
     --version                   Print program version.


### PR DESCRIPTION
fixes deleting of messages in a subfolder, which returned the error:
```ERROR:imap-cli:Can't select directory True```