### PR TITLE
When piping imapcli output, an exception is raised if emails contain …

### DIFF
--- a/examples/multimailboxsearch.py
+++ b/examples/multimailboxsearch.py
@@ -53,7 +53,7 @@ def main():
 
             if len(mail_set) > 0:
                 sys.stdout.write(u'{} Directory\n'.format(
-                    directory_status['directory']))
+                    directory_status['directory']).encode('UTF-8'))
 
                 for mail_info in search.fetch_mails_info(imap_account,
                                                          mail_set=mail_set):
@@ -64,7 +64,7 @@ def main():
                     sys.stdout.write(format_string.format(
                         mail_info['uid'],
                         mail_info['from'],
-                        mail_info['subject']))
+                        mail_info['subject']).encode('UTF-8'))
         imap_cli.disconnect(imap_account)
     except KeyboardInterrupt:
         log.info('Interrupt by user, exiting')

--- a/examples/summary.py
+++ b/examples/summary.py
@@ -42,7 +42,7 @@ def main():
         for directory_status in sorted(imap_cli.status(imap_account),
                                        key=lambda obj: obj['directory']):
             if int(directory_status['unseen']) > 0:
-                sys.stdout.write(directory_status['directory'])
+                sys.stdout.write(directory_status['directory'].encode('UTF-8'))
                 sys.stdout.write('\n')
 
                 imap_cli.change_dir(imap_account,
@@ -62,7 +62,7 @@ def main():
                     sys.stdout.write(format_string.format(
                         mail_info['uid'],
                         mail_info['from'],
-                        mail_info['subject']))
+                        mail_info['subject']).encode('UTF-8'))
         imap_cli.disconnect(imap_account)
     except KeyboardInterrupt:
         log.info('Interrupt by user, exiting')

--- a/imap_cli/fetch.py
+++ b/imap_cli/fetch.py
@@ -201,7 +201,7 @@ def main():
     if len(args['<mail_uid>']) == 0:
         args['<mail_uid>'] = sys.stdin.read().strip().split()
     if len(args['<mail_uid>']) == 0:
-        sys.stderr.write('\n'.join(__doc__.split('\n')[2:]))
+        sys.stderr.write('\n'.join(__doc__.split('\n')[2:]).encode('UTF-8'))
         return 1
 
     conf = config.new_context_from_file(args['--config-file'], section='imap')
@@ -220,7 +220,7 @@ def main():
             return 1
 
         for fetched_mail in fetched_mails:
-            sys.stdout.write(display(fetched_mail))
+            sys.stdout.write(display(fetched_mail).encode('UTF-8'))
 
         imap_cli.disconnect(imap_account)
     except KeyboardInterrupt:

--- a/imap_cli/list_mail.py
+++ b/imap_cli/list_mail.py
@@ -79,7 +79,7 @@ def main():
             for mail_info in search.fetch_mails_info(imap_account,
                                                      limit=limit):
                 sys.stdout.write(
-                    display_conf['format_list'].format(**mail_info))
+                    display_conf['format_list'].format(**mail_info).encode('UTF-8'))
                 sys.stdout.write('\n')
         else:
             threads = search.fetch_threads(imap_account, limit=limit)
@@ -88,7 +88,7 @@ def main():
                     imap_account,
                     mail_tree,
                     format_thread=display_conf['format_thread']):
-                sys.stdout.write(output)
+                sys.stdout.write(output.encode('UTF-8'))
                 sys.stdout.write('\n')
         imap_cli.disconnect(imap_account)
     except KeyboardInterrupt:

--- a/imap_cli/scripts/imap_shell.py
+++ b/imap_cli/scripts/imap_shell.py
@@ -107,7 +107,7 @@ class ImapShell(cmd.Cmd):
                 u'UID : {:<10} From : {:<40.40} Subject : {:.50}\n'.format(
                     mail_info['uid'],
                     mail_info['from'],
-                    mail_info['subject']))
+                    mail_info['subject']).encode('UTF-8'))
 
     def do_mv(self, arg):
         '''Move mail from one mailbox to another.'''
@@ -167,7 +167,7 @@ class ImapShell(cmd.Cmd):
 
             temp_file.close()
         else:
-            sys.stdout.write(fetch.display(fetched_mail))
+            sys.stdout.write(fetch.display(fetched_mail).encode('UTF-8'))
 
     def do_search(self, arg):
         '''Search mail.'''
@@ -217,7 +217,7 @@ class ImapShell(cmd.Cmd):
                 u'UID : {:<10} From : {:<40.40} Subject : {:.50}\n'.format(
                     mail_info['uid'],
                     mail_info['from'],
-                    mail_info['subject']))
+                    mail_info['subject']).encode('UTF-8'))
 
     def do_status(self, arg):
         'Print status of all IMAP folder in this account'
@@ -229,7 +229,7 @@ class ImapShell(cmd.Cmd):
                     directory_status['directory'],
                     directory_status['unseen'],
                     directory_status['recent'],
-                    directory_status['count']))
+                    directory_status['count']).encode('UTF-8'))
 
     def do_unseen(self, arg):
         '''List Unseen mail (equivalent to "search -t unseen").'''
@@ -245,7 +245,7 @@ class ImapShell(cmd.Cmd):
                     u'UID : {:<10} From : {:<40.40} Subject : {:.50}\n'.format(
                         mail_info['uid'],
                         mail_info['from'],
-                        mail_info['subject']))
+                        mail_info['subject']).encode('UTF-8'))
 
     def emptyline(self):
         pass

--- a/imap_cli/search.py
+++ b/imap_cli/search.py
@@ -479,7 +479,7 @@ def main():
             for mail_info in fetch_mails_info(imap_account,
                                               limit=limit, mail_set=mail_set):
                 sys.stdout.write(
-                    display_conf['format_list'].format(**mail_info))
+                    display_conf['format_list'].format(**mail_info).encode('UTF-8'))
                 sys.stdout.write('\n')
         else:
             threads = fetch_threads(imap_account, limit=limit,
@@ -488,7 +488,7 @@ def main():
             for output in display_mail_tree(
                     imap_account, mail_tree,
                     format_thread=display_conf['format_thread']):
-                sys.stdout.write(output)
+                sys.stdout.write(output.encode('UTF-8'))
                 sys.stdout.write('\n')
 
         imap_cli.disconnect(imap_account)

--- a/imap_cli/summary.py
+++ b/imap_cli/summary.py
@@ -58,7 +58,7 @@ def main():
         for directory_status in sorted(imap_cli.status(imap_account),
                                        key=lambda obj: obj['directory']):
             sys.stdout.write(
-                display_conf['format_status'].format(**directory_status))
+                display_conf['format_status'].format(**directory_status).encode('UTF-8'))
             sys.stdout.write('\n')
     except KeyboardInterrupt:
         log.info('Interrupt by user, exiting')


### PR DESCRIPTION
This will typically fail with imapcli:

    $ imapcli search --date 2019-04-01 | less

It will throw an exception, something like this:

    Traceback (most recent call last):
      File "/usr/local/bin/imap-cli-search", line 11, in <module>
        sys.exit(main())
      File "/usr/local/lib/python2.7/dist-packages/imap_cli/search.py", line 484, in main
        sys.stdout.write(text)
    UnicodeEncodeError: 'ascii' codec can't encode character u'\xa0' in position 5: ordinal not in range(128)

When piping imapcli output, an exception is raised if emails contain non-8-bit
characters. This usually does NOT happen during regular usage with a fairly
smart terminal, only during pipe usage. The reason is that stdout, the
device usually used for output, by default just expects non-encoded 8-bit
character data.

This patch fixes this by explicitly encoding everyting into utf-8 before it
is being written to stdout.

(See also this thread on SO: https://stackoverflow.com/questions/15740236/stdout-encoding-in-python )

Cheers